### PR TITLE
Changed struct_DKIM_LIB to DKIM_LIB for newer Go versions.

### DIFF
--- a/dkim.go
+++ b/dkim.go
@@ -130,7 +130,7 @@ const (
 
 // Lib is a dkim library handle
 type Lib struct {
-	lib *C.struct_DKIM_LIB
+	lib *C.DKIM_LIB
 	mtx sync.Mutex
 }
 


### PR DESCRIPTION
Hello,

With the current version of Go, your last version of the OpenDKIM wrapper no longer works, as you now need to explicitly specify the typedef rather than the struct itself in Init().  I have made the changes needed to make the library compile again.

Thanks,
Lachlan
